### PR TITLE
added @types/node as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@hapi/code": "^8.0.3",
     "@hapi/lab": "^24.3.2",
+    "@types/node": "^18.0.0",
     "nock": "^13.1.3",
     "node-forge": "^1.2.1",
     "typescript": "^4.4.2"


### PR DESCRIPTION
will be needed w/ newer versions of `@hapi/code` and `@hapi/lab`