### PR TITLE
export the SnsPayload interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,22 @@ Validator.validate(payloadFromRequest, (err, validPayload) => {
 });
 ```
 
-TypeScript is also supported by using: `import Valiadator from ('sns-payload-validator')`, then using any of the three methods above.\
-\
+### TypeScript
+TypeScript is also supported by using:
+```typescript
+import Validator from 'sns-payload-validator';
+```
+
+If you want to use the `SnsPayload` interface, you can import it using:
+```typescript
+import { SnsPayload } from 'sns-payload-validator/interfaces';
+```
+
+### The Payload
 AWS SNS sends HTTP/S POSTS with the Content-Type of `text/plain`.  Therefore, if there is a need to manipulate the payload before sending it to the AWS SNS Payload Validator, `JSON.parse()` must be used. AWS SNS Payload Validator accepts the payload as a valid JSON `string` or a JavaScript `Object`.  The return value is parsed into a JavaScript `Object`, so it is recommended to do any manipulation on the return value.
 
 ## Examples with Types
-
+Not to be confused with TypesScript, AWS SNS Messages start with a `Type` field.  The `Type` is one of three values: `Notification`, `SubscriptionConfirmation` or `UnsubscribeConfirmation`.
 ### Subscribe / Unsubscribe
 If the endpoint should automaticaly subscribe when the a `SubscriptionConfirmation` is sent. **OR** if the endpoint should resubscribe if a `UnsubscribeConfirmation` is sent, the `SubscribeURL` can be used:
 ```javascript

--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -1,0 +1,14 @@
+export interface SnsPayload {
+    Type: 'Notification' | 'SubscriptionConfirmation' | 'UnsubscribeConfirmation';
+    MessageId: string;
+    Token?: string;
+    TopicArn: string;
+    Subject?: string;
+    Message: string;
+    Timestamp: string;
+    SignatureVersion: '1';
+    Signature: string;
+    SigningCertURL: string;
+    SubscribeURL?: string;
+    UnsubscribeURL?: string;
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,19 +1,4 @@
-/// <reference types="node" />
-
-interface SnsPayload {
-    Type: 'Notification' | 'SubscriptionConfirmation' | 'UnsubscribeConfirmation';
-    MessageId: string;
-    Token?: string;
-    TopicArn: string;
-    Subject?: string;
-    Message: string;
-    Timestamp: string;
-    SignatureVersion: '1';
-    Signature: string;
-    SigningCertURL: string;
-    SubscribeURL?: string;
-    UnsubscribeURL?: string;
-}
+import { SnsPayload } from '../interfaces';
 declare class Validator {
 
     /**


### PR DESCRIPTION
To import the `SnsPayload` interface, use the import statement:
```js
import { SnsPayload } from 'sns-payload-validator/interfaces'l
```

Address #24 