### PR TITLE
Add support for custom https agent

### DIFF
--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -1,3 +1,5 @@
+import { Agent } from 'https';
+
 declare class SnsPayloadValidator {
     /**
     * Instantiates a SnsPayloadValidator object.
@@ -25,6 +27,11 @@ declare namespace SnsPayloadValidator {
         * If the number of certificates exceeds this value, the least recently used certificate will be removed from the cache.
         */
         maxCerts?: number;
+
+        /**
+        * Optional https.Agent for downloading SigningCertURL
+        */
+        requestAgent?: Agent;
     }
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,11 +14,11 @@ const internals = {
 
 internals.getKeys = Keys.getKeys;
 
-internals.getCert = (url) => {
+internals.getCert = (url, requestOptions) => {
 
     return new Promise((resolve, reject) => {
 
-        Https.get(url, (res) => {
+        Https.get(url, requestOptions, (res) => {
 
             let data = '';
             res.on('data', (d) => {
@@ -42,7 +42,7 @@ internals.validateUrl = (url) => {
     return internals.certUrlPattern.test(url);
 };
 
-internals.validateSigature = (payload, certCache) => {
+internals.validateSigature = (payload, certCache, requestAgent) => {
 
     if (payload.SignatureVersion !== '1' && payload.SignatureVersion !== '2') {
         return Promise.reject(new Error('Invalid SignatureVersion'));
@@ -64,7 +64,13 @@ internals.validateSigature = (payload, certCache) => {
         }
     }
 
-    return internals.getCert(certUrl).then((cert) => {
+    const requestOptions = {};
+
+    if (requestAgent) {
+        requestOptions.agent = requestAgent;
+    }
+
+    return internals.getCert(certUrl, requestOptions).then((cert) => {
 
         if (certCache) {
             certCache.set(certUrl, cert);
@@ -110,7 +116,7 @@ internals.verify = (payload, cert, verifier) => {
 
 internals.Validator = class {
 
-    constructor({ useCache = true, maxCerts = 1000 } = {}) {
+    constructor({ useCache = true, maxCerts = 1000, requestAgent } = {}) {
 
         if (typeof useCache !== 'boolean') {
             throw new Error('useCache must be a boolean');
@@ -120,8 +126,14 @@ internals.Validator = class {
             throw new Error('maxCerts must be a positive integer');
         }
 
+        // Since libs like node-tunnel do not extend https.Agent directly, duck typing the requestAgent as https.Agent
+        if (requestAgent && !requestAgent.requests) {
+            throw new Error('requestAgent must be a valid https agent');
+        }
+
         this.useCache = useCache;
         this.maxCerts = maxCerts;
+        this.requestAgent = requestAgent;
 
         if (this.useCache) {
             this.certCache = new LRUCache({ max: this.maxCerts });
@@ -157,7 +169,7 @@ internals.Validator = class {
             return Promise.reject(err);
         }
 
-        payload = internals.validateSigature(payload, this.certCache);
+        payload = internals.validateSigature(payload, this.certCache, this.requestAgent);
 
         if (cb) {
             payload


### PR DESCRIPTION
In order to support scenarios like https://github.com/devinstewart/sns-payload-validator/issues/48, adding an optional `requestAgent` to the validator configuration.

It supports native `https.Agent` and proxy agent created by https://github.com/koichik/node-tunnel