### PR TITLE
Address SonarCloud annotations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Https = require('https');
-const Crypto = require('crypto');
+const Https = require('node:https');
+const Crypto = require('node:crypto');
 const LRUCache = require('lru-cache');
 
 // Put getKeys(key) in own export so it can be used in testing
@@ -119,16 +119,16 @@ internals.Validator = class {
     constructor({ useCache = true, maxCerts = 1000, requestAgent } = {}) {
 
         if (typeof useCache !== 'boolean') {
-            throw new Error('useCache must be a boolean');
+            throw new TypeError('useCache must be a boolean');
         }
 
         if (Number.isInteger(maxCerts) === false || maxCerts < 1) {
-            throw new Error('maxCerts must be a positive integer');
+            throw new TypeError('maxCerts must be a positive integer');
         }
 
         // Since libs like node-tunnel do not extend https.Agent directly, duck typing the requestAgent as https.Agent
         if (requestAgent && !requestAgent.requests) {
-            throw new Error('requestAgent must be a valid https agent');
+            throw new TypeError('requestAgent must be a valid https agent');
         }
 
         this.useCache = useCache;


### PR DESCRIPTION
Address SonarCloud recommendations by:

- Using `node:https` and `node:crypto` core module imports
- Using `TypeError` for constructor argument type validation

No functional changes intended. Kept separate from PR #150 to avoid mixing concerns.